### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+
+## build our base image (used for all stages except prod)
+FROM python:3.12-slim AS base
+
+# set our env vars
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    LANG=C.UTF-8
+
+RUN --mount=type=bind,source=requirements.lock,target=requirements.lock \
+    pip install --no-cache-dir -r requirements.lock
+
+FROM base AS final
+
+RUN groupadd -g 999 python && \
+    useradd -r -u 999 -g python -m python
+
+EXPOSE 8000
+
+USER 999
+
+WORKDIR /app/src
+
+COPY --chown=999:999 ./src/ .
+
+
+FROM final AS develop
+
+RUN --mount=type=bind,source=requirements-dev.lock,target=requirements-dev.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    pip install --no-cache-dir -r requirements-dev.lock
+
+ENTRYPOINT ["uvicorn", "--host", "0.0.0.0", "--reload", "triangler.app:app"]
+
+
+FROM final AS prod
+
+ENTRYPOINT ["uvicorn", "--host", "0.0.0.0", "triangler.app:app"]

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,9 @@ APP_NAME:="triangler"
 
 run-develop-native:
 	zsh -c ". .venv/bin/activate &&  cd src && uvicorn --reload 'triangler.app:app'"
+
+run-develop-docker:
+	docker build --target develop -t ${APP_NAME} . && docker run -it --rm --env-file ./dev.env -v ${ROOT_DIR}/src/${APP_NAME}:/app/src/${APP_NAME} -p 8000:8000 ${APP_NAME}
+
+run-shell-docker:
+	docker build --target develop -t ${APP_NAME} . && docker run --rm -it --env-file ./dev.env -v ${ROOT_DIR}/src/${APP_NAME}:/app/src/${APP_NAME} --entrypoint bash -p 8000:8000 ${APP_NAME}


### PR DESCRIPTION
This PR adds a `Dockerfile` based on the official python 3.12 slim image.

This PR also adds two commands to the `Makefile`:

* one for running the development docker image
* one for running a shell in the development docker image