### PR TITLE
Add unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ managed = true
 virtual = true
 dev-dependencies = [
     "ruff>=0.6.7",
+    "pytest>=8.3.3",
 ]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -19,9 +19,16 @@ httptools==0.6.1
     # via uvicorn
 idna==3.10
     # via anyio
+iniconfig==2.0.0
+    # via pytest
 jinja2==3.1.4
 markupsafe==2.1.5
     # via jinja2
+packaging==24.1
+    # via pytest
+pluggy==1.5.0
+    # via pytest
+pytest==8.3.3
 python-dotenv==1.0.1
     # via uvicorn
 pyyaml==6.0.2

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+PROJECT_PATH = os.getcwd()
+SOURCE_PATH = os.path.join(PROJECT_PATH, "src")
+sys.path.append(SOURCE_PATH)

--- a/src/tests/unit/test_config.py
+++ b/src/tests/unit/test_config.py
@@ -1,0 +1,55 @@
+from typing import Callable, TypeVar
+from unittest import mock
+
+import pytest
+
+from triangler import config
+
+AnyTestMethod = Callable[..., None]
+
+_CONFIG_NAMES_WITH_TESTS: set[str] = set()
+
+C = TypeVar("C", bound=AnyTestMethod)
+
+_ALL_CONFIG_VAR_NAMES: set[str] = set(name for name in dir(config) if name.isupper())
+
+
+def register_config_name(config_name: str) -> Callable[[C], C]:
+    def decorator(func: C) -> C:
+        _CONFIG_NAMES_WITH_TESTS.add(config_name)
+        return func
+
+    return decorator
+
+
+class TestConfig:
+    @pytest.mark.parametrize(
+        ["config_name", "env_value", "expected_boolean"],
+        (
+            ("TEST_VARIABLE", "true", True),
+            ("TEST_VARIABLE", "t", True),
+            ("TEST_VARIABLE", "yes", True),
+            ("TEST_VARIABLE", "y", True),
+            ("TEST_VARIABLE", "1", True),
+            ("TEST_VARIABLE", "some other value", False),
+            ("TEST_VARIABLE", "false", False),
+            ("TEST_VARIABLE", "", False),
+        ),
+    )
+    def test_get_bool_from_env(
+        self, config_name: str, env_value: str, expected_boolean: bool
+    ) -> None:
+        with mock.patch.dict("os.environ", {config_name: env_value}):
+            assert config.get_bool_from_env(config_name) is expected_boolean
+
+    @pytest.mark.parametrize("config_name", _ALL_CONFIG_VAR_NAMES)
+    def test_config_value_has_test(self, config_name: str) -> None:
+        assert config_name in _CONFIG_NAMES_WITH_TESTS
+
+    @register_config_name(config_name="DEBUG")
+    def test_debug_default_is_true(self) -> None:
+        assert config.DEBUG is False
+
+    @register_config_name(config_name="SECRET_KEY")
+    def test_secret_key_default_is_true(self) -> None:
+        assert config.SECRET_KEY == "secret"

--- a/src/triangler/config.py
+++ b/src/triangler/config.py
@@ -1,1 +1,27 @@
-DEBUG = True
+import os
+
+
+def get_bool_from_env(env_var: str, default: bool | None = None) -> bool | None:
+    """
+    Get a boolean value from an environment variable. If the environment variable is not set,
+    return the default.
+
+
+    :param env_var: The environment variable to get the boolean value from.
+    :param default: The default value to return if the environment variable is not set.
+    :return: The boolean value of the environment variable or the default.
+    """
+    if env_var not in os.environ:
+        return default
+    return os.environ.get(env_var, "false").lower() in ("true", "t", "1", "yes", "y")
+
+
+def get_str_from_env(env_var: str, default: str | None = None) -> str | None:
+    if env_var not in os.environ:
+        return default
+    return os.environ.get(env_var)
+
+
+DEBUG = get_bool_from_env("DEBUG", False)
+
+SECRET_KEY = get_str_from_env("SECRET_KEY", "secret")


### PR DESCRIPTION
This PR:

* Adds the `pytest` package.
* Adds a `conftest.py` file to ensure that the `triangler` namespace is available for importing in tests.
* Updates the `config.py` module to include some useful functions.
* Adds tests for the `config.py` module.